### PR TITLE
docs(README.quick start): clarify installation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,10 +183,13 @@ To use Vimspector with a language that's not "built-in", see this
 
 ## Quick Start
 
-There are 2 installation methods:
+There are 3 installation methods:
 
-* Using a release tarball and vim packages
-* Using a clone of the repo (e.g. package manager)
+* Using a release tarball and Vim packages
+* Using a clone of the repo and Vim packages
+* Using a plugin manager
+
+**Way1: Using a release tarball and Vim packages**
 
 Release tarballs come with debug adapters for the default languages
 pre-packaged. To use a release tarball:
@@ -194,7 +197,7 @@ pre-packaged. To use a release tarball:
 1. Check the dependencies
 2. Untar the release tarball for your OS into `$HOME/.vim/pack`:
 
-```
+```bash
 $ mkdir -p $HOME/.vim/pack
 $ curl -L <url> | tar -C $HOME/.vim/pack zxvf -
 ```
@@ -203,28 +206,32 @@ $ curl -L <url> | tar -C $HOME/.vim/pack zxvf -
 
 4. (optionally) Enable the default set of mappings:
 
-```
+```vim
 let g:vimspector_enable_mappings = 'HUMAN'
 ```
 
 5. Configure your project's debug profiles (create `.vimspector.json`, or set
-   `g:vimspector_configurations`)
+   `g:vimspector_configurations`) - see the [reference guide](https://puremourning.github.io/vimspector/configuration.html)
 
-Alternatively, you can clone the repo and select which gadgets are installed:
+**Way2: Using a clone the repo, Vim packages and select gadgets to be installed**
 
 1. Check the dependencies
 1. Install the plugin as a Vim package. See `:help packages`.
 2. Add `packadd! vimspector` to you `.vimrc`
-2. Install some 'gadgets' (debug adapters) - see `:VimspectorInstall ...`
+2. Install some 'gadgets' (debug adapters) - see `:h vimspector-install-gadgets` in Vim or [supported languages](https://github.com/puremourning/vimspector#supported-languages)
 3. Configure your project's debug profiles (create `.vimspector.json`, or set
-   `g:vimspector_configurations`)
+   `g:vimspector_configurations`) - see the [reference guide](https://puremourning.github.io/vimspector/configuration.html)
 
-If you prefer to use a plugin manager, see the plugin manager's docs. For
-Vundle, use:
+**Way3: Using a plugin manager**
 
-```vim
-Plugin 'puremourning/vimspector'
-```
+1. See the plugin manager's docs and install  
+   For Vundle, use:
+   ```vim
+   Plugin 'puremourning/vimspector'
+   ```
+2. Install some 'gadgets' (debug adapters) - see `:h vimspector-install-gadgets` in Vim or [supported languages](https://github.com/puremourning/vimspector#supported-languages)
+3. Configure your project's debug profiles (create `.vimspector.json`, or set
+   `g:vimspector_configurations`) - see the [reference guide](https://puremourning.github.io/vimspector/configuration.html)
 
 The following sections expand on the above brief overview.
 


### PR DESCRIPTION
I think the original guideline is a little bit confusing regarding to the difference between using a Git clone and using plugin managers.
Secondly, I linked the concepts about the `.vimspector.json` reference guide and the reference to gadgets. Hopefully [issues like this](https://github.com/puremourning/vimspector/issues/621#issuecomment-1181503298) would become less and less.

However, I'm not sure whether ["Check the dependencies"](https://github.com/puremourning/vimspector/blob/0602a20e99b04d90a3ce161a884b1b5522a5006e/README.md?plain=1#L194) is relevant to ["Dependencies" section in README](https://github.com/puremourning/vimspector#dependencies). If this is currect, I will add this to the installation method "Using a plugin manager"